### PR TITLE
Feat/add argocd cluster

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Export kubeconfig var
         id: exportar_variable
-        run: echo "::set-output name=kubeconfig::$(cat $HOME/.kube/config | base64)"
+        run: echo "::set-output name=kubeconfig::$(cat $HOME/.kube/config | base64)" # yamllint disable-line rule:line-length
 
       - name: Install Argo application
         uses: actions-hub/kubectl@master

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -51,6 +51,21 @@ jobs:
       - name: Terraform Apply
         run: terraform apply -auto-approve -input=false
 
+      - name: Move kubeconfig
+        run: mv kubeconfig ~/.kube/config
+
+      - name: Export kubeconfig var
+        id: exportar_variable
+        run: |
+          echo "::set-output name=kubeconfig::$(cat $HOME/.kube/config | base64)"
+
+      - name: Install Argo application
+        uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ steps.exportar_variable.outputs.kubeconfig }}
+        with:
+          args: apply -f ../argo-app/repo-pull.yaml
+
       - name: Bump version and push tag
         uses: anothrNick/github-tag-action@1.55.0
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Export kubeconfig var
         id: exportar_variable
         run: |
-          echo "::set-output name=kubeconfig::$(cat $HOME/.kube/config | base64)"
+        echo "::set-output name=kubeconfig::$(cat $HOME/.kube/config | base64)"
 
       - name: Install Argo application
         uses: actions-hub/kubectl@master

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -57,7 +57,8 @@ jobs:
       - name: Export kubeconfig var
         id: exportar_variable
         run: |
-        echo "::set-output name=kubeconfig::$(cat $HOME/.kube/config | base64)"
+          echo "::set-output name=kubeconfig::$(cat $HOME/.kube/config | 
+          base64)"
 
       - name: Install Argo application
         uses: actions-hub/kubectl@master

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -56,9 +56,7 @@ jobs:
 
       - name: Export kubeconfig var
         id: exportar_variable
-        run: |
-          echo "::set-output name=kubeconfig::$(cat $HOME/.kube/config | 
-          base64)"
+        run: echo "::set-output name=kubeconfig::$(cat $HOME/.kube/config | base64)"
 
       - name: Install Argo application
         uses: actions-hub/kubectl@master

--- a/argo-app/repo-pull.yaml
+++ b/argo-app/repo-pull.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/argo-app/repo-pull.yaml
+++ b/argo-app/repo-pull.yaml
@@ -2,14 +2,14 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: test-env
+  name: core-apps
   namespace: argocd
 spec:
   destination:
     name: ""
     server: "https://kubernetes.default.svc"
   source:
-    path: applications/test
+    path: core
     repoURL: "https://github.com/cloudnativerioja/cluster-applications.git"
     targetRevision: HEAD
     directory:

--- a/argo-app/repo-pull.yaml
+++ b/argo-app/repo-pull.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-env
+  namespace: argocd
+spec:
+  destination:
+    name: ""
+    server: "https://kubernetes.default.svc"
+  source:
+    path: applications/test
+    repoURL: "https://github.com/cloudnativerioja/cluster-applications.git"
+    targetRevision: HEAD
+    directory:
+      recurse: true
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        maxDuration: 3m0s
+        factor: 2
+    syncOptions: []

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,6 @@ cluster:
   cni: cilium
   label-nodes: demos-first-pool
   region: LON1
-  applications: "argo-cd"
+  applications: "argo-cd,traefik"
 firewall:
   name: demo-firewall

--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,6 @@ cluster:
   cni: cilium
   label-nodes: demos-first-pool
   region: LON1
-# Opcionales, se ponen dentro del mismo string una detras de otra
-# applications: "argo-cd"
+  applications: "argo-cd"
 firewall:
   name: demo-firewall


### PR DESCRIPTION
Antes se tiene que mergear a la rama Master esta PR https://github.com/cloudnativerioja/cluster-applications/pull/1

- Se despliega ArgoCD y Traefik en el cluster, se controla por terraform desde el fichero config.yaml
- Se crea una aplicación que hará pull de los manifests en forma recursiva del path applications/test del repositorio https://github.com/cloudnativerioja/cluster-applications
- Se aplica con kubectl para controlarlo en cada release de manera automática con github actions