### PR TITLE
fix(argocd): install CRDs on deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -65,6 +65,7 @@ jobs:
       - name: Install Argo application
         working-directory: ./argo-app
         run: |
+          kubectl apply -f https://github.com/argoproj/argo-cd/tree/stable/manifests/crds
           kubectl apply -f . --recursive
 
       - name: Bump version and push tag

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,9 +64,11 @@ jobs:
 
       - name: Install Argo application
         working-directory: ./argo-app
+        # yamllint disable rule:line-length
         run: |
-          kubectl apply -f https://github.com/argoproj/argo-cd/tree/stable/manifests/crds # yamllint disable-line rule:line-length
+          kubectl apply -f https://github.com/argoproj/argo-cd/tree/stable/manifests/crds
           kubectl apply -f . --recursive
+        # yamllint enable rule:line-length
 
       - name: Bump version and push tag
         uses: anothrNick/github-tag-action@1.55.0

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Install Argo application
         working-directory: ./argo-app
         run: |
-          kubectl apply -f https://github.com/argoproj/argo-cd/tree/stable/manifests/crds
+          kubectl apply -f https://github.com/argoproj/argo-cd/tree/stable/manifests/crds # yamllint disable-line rule:line-length
           kubectl apply -f . --recursive
 
       - name: Bump version and push tag


### PR DESCRIPTION
<!--- 🚀 Pull Request Template 🚀 -->

## Description 📝
Argo CD CRDs are not included and have to be installed separately. The CRD manifests are located in the [manifests/crds](https://github.com/argoproj/argo-cd/tree/stable/manifests/crds) directory.

## Related Issues 🔗

## Screenshots/Visuals 📸
![image](https://github.com/cloudnativerioja/cluster-demos/assets/7888227/96c33a68-8992-4e44-9f76-c17c116e4d27)

## Testing Checklist 🧪

✅ Please check the following items before submitting your PR:

- [ ] Code compiles and runs successfully.
- [ ] All existing tests pass.
- [ ] Added new tests (if applicable).
- [ ] Documentation is updated (if applicable).
- [x] Followed coding style and best practices.
- [ ] Reviewed your own code.

## Additional Comments 💬

<!--- 🙏 Thank you for your contribution! 🙏 -->
