### PR TITLE
Feat: avoid terraform drifts with ignore changes

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -23,6 +23,9 @@ resource "civo_kubernetes_cluster" "demo-cluster" {
     size       = element(data.civo_size.medium.sizes, 0).name
     node_count = local.cluster.nodes
   }
+  lifecycle {
+    ignore_changes = [pools]
+  }
 }
 
 # Add a node pool
@@ -41,5 +44,8 @@ resource "civo_kubernetes_node_pool" "runners" {
     key    = "runners"
     value  = "true"
     effect = "NoSchedule"
+  }
+  lifecycle {
+    ignore_changes = [node_count]
   }
 }


### PR DESCRIPTION
<!--- 🚀 Pull Request Template 🚀 -->

## Description 📝
* There is a drift about nodes size because cluster autoscaler
* To avoid it, it is required a lifecycle with ignore_changes

## Related Issues 🔗

## Screenshots/Visuals 📸

## Testing Checklist 🧪

✅ Please check the following items before submitting your PR:

- [ ] Code compiles and runs successfully.
- [ ] All existing tests pass.
- [ ] Added new tests (if applicable).
- [ ] Documentation is updated (if applicable).
- [ ] Followed coding style and best practices.
- [ ] Reviewed your own code.

## Additional Comments 💬

<!--- 🙏 Thank you for your contribution! 🙏 -->
